### PR TITLE
Use https whilst download assets

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -128,8 +128,8 @@ public class Constants {
 
     // urls
     public static final String URL_MC_MANIFEST = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
-    public static final String URL_FF = "http://files.minecraftforge.net/fernflower-fix-1.0.zip";
-    public static final String URL_ASSETS = "http://resources.download.minecraft.net";
+    public static final String URL_FF = "https://files.minecraftforge.net/fernflower-fix-1.0.zip";
+    public static final String URL_ASSETS = "https://resources.download.minecraft.net";
     public static final String URL_LIBRARY = "https://libraries.minecraft.net/";
     public static final String URL_FORGE_MAVEN = "https://maven.minecraftforge.net/";
     public static final String URL_MCP_JSON = "https://maven.minecraftforge.net/de/oceanlabs/mcp/versions.json";


### PR DESCRIPTION
Minecraft Resource server rejects non-https request with the response below
~~~
<Error>
<Code>AccountRequiresHttps</Code>
<Message>The account being accessed does not support http. RequestId: Time:</Message>
<AccountName>resourcesdownloadminecra</AccountName>
</Error>
~~~